### PR TITLE
[FP2] Fix lk compilation

### DIFF
--- a/lkshim/init.c
+++ b/lkshim/init.c
@@ -1,6 +1,5 @@
 #include <pm8x41.h>
 #include <platform/timer.h>
-#include <dev/newkeys.h>
 #include <err.h>
 
 /* Return 1 if vol_down pressed */


### PR DESCRIPTION
dev/newkeys.h doesn't get used in init.c

Introduced in 1e272a1